### PR TITLE
feat: FastAPIでSlack Bot用のエンドポイントを実装

### DIFF
--- a/fastapi_README.md
+++ b/fastapi_README.md
@@ -1,0 +1,120 @@
+# FastAPI Implementation for Slack Bot
+
+このファイルは、Lambda関数とは別に、FastAPIを使用してSlack Botを実行するための実装です。
+
+## 概要
+
+`slack_app.py` は、以下の機能を提供するFastAPIアプリケーションです：
+
+- `/slack/events` - Slackイベント（メンション、DM）を処理
+- `/slack/slash/dinner` - `/dinner` スラッシュコマンドを処理
+- 既存のレシピサービスとの統合
+- Slack署名検証
+
+## セットアップ
+
+1. **環境変数の設定**
+
+```bash
+export SLACK_BOT_TOKEN="xoxb-your-bot-token"
+export SLACK_SIGNING_SECRET="your-signing-secret"
+export AWS_REGION="us-east-1"
+export BEDROCK_MODEL_ID="anthropic.claude-3-5-sonnet-20241022-v2:0"
+```
+
+2. **依存関係のインストール**
+
+```bash
+pip install -r requirements.txt
+```
+
+3. **アプリケーションの起動**
+
+```bash
+python slack_app.py
+```
+
+または、uvicornを直接使用：
+
+```bash
+uvicorn slack_app:app --reload --host 0.0.0.0 --port 8000
+```
+
+## Slack Appの設定
+
+### Event Subscriptions
+
+1. Slack App設定ページで「Event Subscriptions」を有効化
+2. Request URL: `https://your-domain.com/slack/events`
+3. Subscribe to bot events:
+   - `app_mention` - ボットがメンションされた時
+   - `message.im` - DMを受信した時
+
+### Slash Commands
+
+1. Slack App設定ページで「Slash Commands」を追加
+2. Command: `/dinner`
+3. Request URL: `https://your-domain.com/slack/slash/dinner`
+4. Short Description: 晩御飯のメニューを提案します
+5. Usage Hint: [食材や気分]
+
+### OAuth & Permissions
+
+必要なBot Token Scopes:
+- `chat:write` - メッセージを送信
+- `commands` - スラッシュコマンドを受信
+- `app_mentions:read` - メンションを読み取り
+- `im:read` - DMを読み取り
+- `im:history` - DM履歴を読み取り
+
+## ローカル開発
+
+ngrokを使用してローカル開発環境でテスト：
+
+```bash
+# FastAPIを起動
+python slack_app.py
+
+# 別のターミナルでngrokを起動
+ngrok http 8000
+```
+
+ngrokのHTTPS URLをSlack Appの設定に使用してください。
+
+## エンドポイント
+
+### GET /
+ヘルスチェック用エンドポイント
+
+### POST /slack/events
+Slackイベントを処理:
+- URL検証チャレンジ
+- アプリメンション
+- ダイレクトメッセージ
+
+### POST /slack/slash/dinner
+`/dinner` スラッシュコマンドを処理
+
+## Lambda vs FastAPI
+
+| 項目 | Lambda | FastAPI |
+|------|--------|---------|
+| デプロイ | AWS Lambda | EC2/ECS/K8s等 |
+| スケーリング | 自動 | 手動設定必要 |
+| コスト | 使用分のみ | 常時稼働 |
+| ローカル開発 | 複雑 | 簡単 |
+| レスポンス時間 | コールドスタート有 | 常時高速 |
+
+## トラブルシューティング
+
+### 署名検証エラー
+- `SLACK_SIGNING_SECRET`が正しく設定されているか確認
+- リクエストのタイムスタンプが5分以内か確認
+
+### メッセージが送信されない
+- `SLACK_BOT_TOKEN`が正しく設定されているか確認
+- Bot Token Scopesが適切に設定されているか確認
+
+### イベントが受信されない
+- Event SubscriptionsのURLが正しいか確認
+- ngrokを使用している場合、URLが最新か確認

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ boto3==1.34.14
 python-dotenv==1.0.0
 requests==2.31.0
 slack-sdk==3.27.1
+fastapi==0.109.0
+uvicorn[standard]==0.27.0
+python-multipart==0.0.6

--- a/slack_app.py
+++ b/slack_app.py
@@ -1,0 +1,428 @@
+"""
+FastAPI implementation for Slack Bot endpoints
+Provides local development and alternative deployment option for the Lambda-based bot
+"""
+from fastapi import FastAPI, Request, Header, HTTPException
+from fastapi.responses import JSONResponse, PlainTextResponse
+import hmac
+import hashlib
+import os
+import time
+import json
+import logging
+from typing import Optional, Dict, Any
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+# Import the existing recipe service from the Lambda app
+from app.core.recipe_service import create_recipe_service
+from app.utils.logger import setup_logger
+
+# Setup logging
+logger = setup_logger(__name__)
+
+# Initialize FastAPI app
+app = FastAPI(
+    title="Dinner Suggestion Bot API",
+    description="FastAPI endpoints for Slack integration",
+    version="1.0.0"
+)
+
+# Environment variables
+SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN")
+SLACK_SIGNING_SECRET = os.getenv("SLACK_SIGNING_SECRET")
+
+# Initialize Slack client
+slack_client = WebClient(token=SLACK_BOT_TOKEN) if SLACK_BOT_TOKEN else None
+
+# Initialize recipe service
+recipe_service = create_recipe_service()
+
+
+def verify_slack_signature(
+    body: bytes,
+    slack_signature: str,
+    slack_timestamp: str
+) -> bool:
+    """
+    Verify Slack request signature
+    
+    Args:
+        body: Raw request body
+        slack_signature: X-Slack-Signature header
+        slack_timestamp: X-Slack-Request-Timestamp header
+        
+    Returns:
+        True if signature is valid
+    """
+    if not SLACK_SIGNING_SECRET:
+        logger.warning("SLACK_SIGNING_SECRET not configured, skipping verification")
+        return True
+    
+    # Check timestamp to prevent replay attacks (5 minutes)
+    if abs(time.time() - int(slack_timestamp)) > 60 * 5:
+        logger.error("Slack request timestamp too old")
+        return False
+    
+    # Create signature base string
+    basestring = f"v0:{slack_timestamp}:{body.decode('utf-8')}"
+    
+    # Calculate expected signature
+    my_signature = "v0=" + hmac.new(
+        SLACK_SIGNING_SECRET.encode(),
+        basestring.encode(),
+        hashlib.sha256
+    ).hexdigest()
+    
+    # Compare signatures
+    return hmac.compare_digest(my_signature, slack_signature)
+
+
+def send_slack_message(channel: str, text: str, blocks: Optional[list] = None) -> bool:
+    """
+    Send a message to Slack channel
+    
+    Args:
+        channel: Channel ID to send message to
+        text: Message text
+        blocks: Optional Block Kit blocks
+        
+    Returns:
+        True if message sent successfully
+    """
+    if not slack_client:
+        logger.error("Slack client not initialized")
+        return False
+    
+    try:
+        response = slack_client.chat_postMessage(
+            channel=channel,
+            text=text,
+            blocks=blocks
+        )
+        return response["ok"]
+    except SlackApiError as e:
+        logger.error(f"Failed to send Slack message: {e.response['error']}")
+        return False
+
+
+def format_recipe_blocks(recipes: list, input_type: str) -> list:
+    """
+    Format recipes as Slack Block Kit blocks
+    
+    Args:
+        recipes: List of recipe dicts
+        input_type: 'mood' or 'ingredient'
+        
+    Returns:
+        List of Block Kit blocks
+    """
+    blocks = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "🍽️ メニュー提案"
+            }
+        }
+    ]
+    
+    # Add context about input type
+    context_text = "気分に合わせた提案" if input_type == "mood" else "食材を使った提案"
+    blocks.append({
+        "type": "context",
+        "elements": [{
+            "type": "mrkdwn",
+            "text": f"_{context_text}_"
+        }]
+    })
+    
+    # Add each recipe as a section
+    for recipe in recipes:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*{recipe['number']}. {recipe['name']}*\n{recipe['description']}"
+            }
+        })
+    
+    # Add divider at the end
+    blocks.append({"type": "divider"})
+    
+    return blocks
+
+
+def remove_bot_mention(text: str) -> str:
+    """Remove bot mention from message text"""
+    import re
+    return re.sub(r'<@[A-Z0-9]+>', '', text).strip()
+
+
+@app.get("/")
+async def root():
+    """Health check endpoint"""
+    return {"status": "ok", "service": "Dinner Suggestion Bot FastAPI"}
+
+
+@app.post("/slack/events")
+async def slack_events(
+    request: Request,
+    x_slack_signature: Optional[str] = Header(None),
+    x_slack_request_timestamp: Optional[str] = Header(None)
+):
+    """
+    Handle Slack events (mentions, DMs, url_verification)
+    
+    This endpoint handles:
+    - URL verification challenges from Slack
+    - Event callbacks (app_mention, message.im)
+    """
+    # Get request body
+    body = await request.body()
+    
+    # Verify Slack signature
+    if not verify_slack_signature(body, x_slack_signature, x_slack_request_timestamp):
+        logger.error("Invalid Slack signature")
+        raise HTTPException(status_code=403, detail="Invalid Slack signature")
+    
+    # Parse JSON payload
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        logger.error("Invalid JSON in request body")
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+    
+    # Handle URL verification challenge
+    if payload.get("type") == "url_verification":
+        challenge = payload.get("challenge")
+        logger.info(f"Handling url_verification with challenge: {challenge}")
+        return PlainTextResponse(content=challenge)
+    
+    # Handle event callback
+    if payload.get("type") == "event_callback":
+        event = payload.get("event", {})
+        event_type = event.get("type")
+        
+        logger.info(f"Handling event: {event_type}")
+        
+        if event_type == "app_mention":
+            # Bot was mentioned
+            text = event.get("text", "")
+            channel = event.get("channel")
+            user = event.get("user")
+            
+            # Remove bot mention from text
+            text = remove_bot_mention(text)
+            
+            logger.info(f"App mention from user {user}: {text}")
+            
+            # Generate recipe suggestions
+            if text.strip():
+                result = recipe_service.generate_recipe_suggestions(
+                    user_input=text,
+                    channel="slack"
+                )
+                
+                if result["success"]:
+                    # Format and send response
+                    blocks = format_recipe_blocks(
+                        result["recipes"],
+                        result["input_type"]
+                    )
+                    send_slack_message(
+                        channel=channel,
+                        text="🍽️ メニュー提案",
+                        blocks=blocks
+                    )
+                else:
+                    # Send error message
+                    send_slack_message(
+                        channel=channel,
+                        text=f"⚠️ エラーが発生しました: {result.get('error', 'Unknown error')}"
+                    )
+            else:
+                # Send help message
+                help_blocks = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*晩御飯提案BOTの使い方*\n\n食材や気分を教えてください。美味しいメニューを提案します！"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*📝 使用例*\n• キャベツと鶏肉\n• さっぱりしたものが食べたい\n• 夏バテで食欲ない\n• こってり系でスタミナつくもの"
+                        }
+                    }
+                ]
+                send_slack_message(
+                    channel=channel,
+                    text="🍽️ 晩御飯提案BOTの使い方",
+                    blocks=help_blocks
+                )
+        
+        elif event_type == "message" and event.get("channel_type") == "im":
+            # Direct message
+            text = event.get("text", "")
+            channel = event.get("channel")
+            user = event.get("user")
+            
+            # Skip bot messages
+            if event.get("bot_id"):
+                return JSONResponse(content={"status": "ok"})
+            
+            logger.info(f"DM from user {user}: {text}")
+            
+            # Generate recipe suggestions
+            if text.strip():
+                result = recipe_service.generate_recipe_suggestions(
+                    user_input=text,
+                    channel="slack"
+                )
+                
+                if result["success"]:
+                    # Format and send response
+                    blocks = format_recipe_blocks(
+                        result["recipes"],
+                        result["input_type"]
+                    )
+                    send_slack_message(
+                        channel=channel,
+                        text="🍽️ メニュー提案",
+                        blocks=blocks
+                    )
+                else:
+                    # Send error message
+                    send_slack_message(
+                        channel=channel,
+                        text=f"⚠️ エラーが発生しました: {result.get('error', 'Unknown error')}"
+                    )
+            else:
+                # Send help message
+                help_blocks = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*晩御飯提案BOTの使い方*\n\n食材や気分を教えてください。美味しいメニューを提案します！"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*📝 使用例*\n• キャベツと鶏肉\n• さっぱりしたものが食べたい\n• 夏バテで食欲ない\n• こってり系でスタミナつくもの"
+                        }
+                    }
+                ]
+                send_slack_message(
+                    channel=channel,
+                    text="🍽️ 晩御飯提案BOTの使い方",
+                    blocks=help_blocks
+                )
+    
+    # Return OK response
+    return JSONResponse(content={"status": "ok"})
+
+
+@app.post("/slack/slash/dinner")
+async def slack_slash_dinner(
+    request: Request,
+    x_slack_signature: Optional[str] = Header(None),
+    x_slack_request_timestamp: Optional[str] = Header(None)
+):
+    """
+    Handle /dinner slash command
+    
+    This endpoint processes the /dinner command and returns recipe suggestions
+    """
+    # Get request body
+    body = await request.body()
+    
+    # Verify Slack signature
+    if not verify_slack_signature(body, x_slack_signature, x_slack_request_timestamp):
+        logger.error("Invalid Slack signature")
+        raise HTTPException(status_code=403, detail="Invalid Slack signature")
+    
+    # Parse form data
+    form_data = await request.form()
+    
+    # Extract relevant information
+    user_id = form_data.get("user_id", "")
+    user_name = form_data.get("user_name", "")
+    text = form_data.get("text", "")
+    channel_id = form_data.get("channel_id", "")
+    
+    logger.info(f"Slash command from {user_name} ({user_id}): {text}")
+    
+    # If no text provided, show help
+    if not text.strip():
+        return JSONResponse(content={
+            "response_type": "ephemeral",
+            "text": "🍽️ 晩御飯提案BOTの使い方",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*晩御飯提案BOTの使い方*\n\n食材や気分を教えてください。美味しいメニューを提案します！"
+                    }
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*📝 使用例*\n• `/dinner キャベツと鶏肉`\n• `/dinner さっぱりしたものが食べたい`\n• `/dinner 夏バテで食欲ない`\n• `/dinner こってり系でスタミナつくもの`"
+                    }
+                }
+            ]
+        })
+    
+    # Generate recipe suggestions
+    result = recipe_service.generate_recipe_suggestions(
+        user_input=text,
+        channel="slack"
+    )
+    
+    if result["success"]:
+        # Format response
+        blocks = format_recipe_blocks(
+            result["recipes"],
+            result["input_type"]
+        )
+        
+        return JSONResponse(content={
+            "response_type": "in_channel",
+            "text": "🍽️ メニュー提案",
+            "blocks": blocks
+        })
+    else:
+        # Return error message
+        error_message = {
+            "The service is currently experiencing high demand. Please try again in a moment.": 
+                "現在アクセスが集中しています。少し時間をおいてからお試しください。",
+            "The AI model is preparing. Please wait a moment and try again.":
+                "AIモデルが準備中です。しばらくお待ちください。",
+            "An error occurred while processing your request.":
+                "レシピの生成中にエラーが発生しました。"
+        }.get(result.get("error"), "エラーが発生しました。もう一度お試しください。")
+        
+        return JSONResponse(content={
+            "response_type": "ephemeral",
+            "text": f"⚠️ {error_message}"
+        })
+
+
+if __name__ == "__main__":
+    import uvicorn
+    # Run the FastAPI app
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        log_level="info"
+    )


### PR DESCRIPTION
## 🎯 概要

FastAPIでSlack Bot用の `/slack/events` エンドポイントを実装しました。

## ✅ 実装内容

- `/slack/events` エンドポイントを追加（イベント処理用）
- `/slack/slash/dinner` エンドポイントを追加（スラッシュコマンド用）
- Slack署名検証を実装
- url_verificationとevent_callbackの処理を実装
- 既存のレシピサービスとの統合
- FastAPI関連の依存関係を追加

Closes #13

---